### PR TITLE
Automate formula release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ Run the following in your command-line:
 $ brew tap confluentinc/homebrew-confluent-hub-client 
 $ brew cask install confluent-hub-client
 ```
+
+# Release management
+## Prepare new formula's version for release:
+
+- Use following Jenkins job: https://jenkins.confluent.io/job/hub-client-prepare-release-brew/.
+
+| Parameter name  | Meaning                                                                                                     |
+| --------------- |:-----------------------------------------------------------------------------------------------------------:|
+| RELEASE_TAG     | Which tag to use for an archive                                                                             |
+| UPDATE_LATEST   | Update the latest version, available here http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz |
+
+- Submit a PR for bumping up a formula
+The previous job should generate a link for submitting a PR, i.e.:
+
+```
+remote:
+remote: Create a pull request for 'prepare-v6.0.0-beta181009071136' on GitHub by visiting:
+remote:      https://github.com/sansanichfb/homebrew-confluent-hub-client/pull/new/prepare-v6.0.0-beta181009071136
+```
+
+## Finalize release
+Get approval and merge a PR.
+After PR is merged, users should have access to the updated version of Confluent Hub client via brew cask formula.

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -x
+
 if [ -z "$RELEASE_TAG" ]
 then
   echo "\$RELEASE_TAG is empty"

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -6,6 +6,8 @@ then
   exit 1
 fi
 
+echo "UPDATE_LATEST=$UPDATE_LATEST"
+
 version=${RELEASE_TAG:1}
 
 cd /tmp

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -57,5 +57,4 @@ sed -i -E "s/version '.*'/version '$version'/g" Casks/confluent-hub-client.rb
 sed -i -E "s/sha256 '.*'/sha256 '$sha_sum'/g" Casks/confluent-hub-client.rb
 git add Casks/confluent-hub-client.rb
 git commit -m "Bump up formula to $RELEASE_TAG"
-git remote add owner git@github.com:$PR_REPOSITORY_OWNER/homebrew-confluent-hub-client.git
-git push owner "prepare-$RELEASE_TAG"
+git push origin "prepare-$RELEASE_TAG"

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -30,7 +30,7 @@ gradle
 ./gradlew clients:install connect:api:install connect:runtime:install install_2_11
 cd -
 
-for repo in common private-common license-file-generator; do
+for repo in license-file-generator common private-common; do
 	install_mvn_dependency $repo
 done
 

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -57,4 +57,5 @@ sed -i -E "s/version '.*'/version '$version'/g" Casks/confluent-hub-client.rb
 sed -i -E "s/sha256 '.*'/sha256 '$sha_sum'/g" Casks/confluent-hub-client.rb
 git add Casks/confluent-hub-client.rb
 git commit -m "Bump up formula to $RELEASE_TAG"
-git push origin "prepare-$RELEASE_TAG"
+git remote add owner git@github.com:$PR_REPOSITORY_OWNER/homebrew-confluent-hub-client.git
+git push owner "prepare-$RELEASE_TAG"

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -20,7 +20,7 @@ git clone git@github.com:confluentinc/kafka.git
 cd kafka
 git checkout $RELEASE_TAG
 gradle
-./gradlew installAll
+./gradlew clients:install connect:api:install connect:runtime:install install_2_11
 cd -
 
 rm -rf common
@@ -30,6 +30,7 @@ git checkout $RELEASE_TAG
 mvn clean install -DskipTests
 cd -
 
+rm -rf private-common
 git clone git@github.com:confluentinc/private-common.git
 cd private-common
 git checkout $RELEASE_TAG

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [ -z "$RELEASE_TAG" ]
+then
+  echo "\$RELEASE_TAG is empty"
+  exit 1
+fi
+
+version=${RELEASE_TAG:1}
+
+cd /tmp
+
+rm -rf kafka
+git clone git@github.com:confluentinc/kafka.git
+cd kafka
+git checkout $RELEASE_TAG
+gradle
+./gradlew installAll
+cd -
+
+rm -rf common
+git clone git@github.com:confluentinc/common.git
+cd common
+git checkout $RELEASE_TAG
+mvn clean install -DskipTests
+cd -
+
+git clone git@github.com:confluentinc/private-common.git
+cd private-common
+git checkout $RELEASE_TAG
+mvn clean install -DskipTests
+cd -
+
+rm -rf hub-client
+git clone git@github.com:confluentinc/hub-client.git
+cd hub-client
+git checkout $RELEASE_TAG
+mvn clean package
+shasum -a 256 target/confluent-hub-client-*-package.tar.gz | cut -c1-64 > $(ls target/confluent-hub-client-*-package.tar.gz).sha256.txt
+sha_sum=$(cat target/confluent-hub-client-*-package.tar.gz.sha256.txt)
+aws s3 cp target/confluent-hub-client-*-package.tar.gz s3://client.hub.confluent.io/
+aws s3 cp target/confluent-hub-client-*-package.tar.gz.sha256.txt s3://client.hub.confluent.io/
+
+rm -rf homebrew-confluent-hub-client
+git clone git@github.com:confluentinc/homebrew-confluent-hub-client.git
+cd homebrew-confluent-hub-client
+git checkout -b "prepare-$RELEASE_TAG"
+sed -i -E "s/version '.*'/version '$version'/g" Casks/confluent-hub-client.rb
+sed -i -E "s/sha256 '.*'/sha256 '$sha_sum'/g" Casks/confluent-hub-client.rb
+git add Casks/confluent-hub-client.rb
+git commit -m "Bump up formula to $RELEASE_TAG"
+git push origin "prepare-$RELEASE_TAG"
+


### PR DESCRIPTION
This script is needed by https://jenkins.confluent.io/job/hub-client-prepare-release-brew/ job.
It builds and uploads Confluent Hub client's archive to S3 bucket and pushes branches with the bumped up version of the formula.