### PR TITLE
Bump up formula to v5.0.1

### DIFF
--- a/Casks/confluent-hub-client.rb
+++ b/Casks/confluent-hub-client.rb
@@ -1,6 +1,6 @@
 cask 'confluent-hub-client' do
-  version '5.0.1-SNAPSHOT'
-  sha256 '3bf8a99e08b2dafe91ea6c114c1960f8cedc57c3df8a0bce77d01a4c68dc11d3'
+  version '5.0.1'
+  sha256 'a640fbbdf6c750c82716a29afc2b76847f622218dd8521cdd9dccaf509ebc13d'
   url "http://client.hub.confluent.io/confluent-hub-client-#{version}-package.tar.gz"
   name 'Confluent Hub Client'
   homepage 'https://www.confluent.io/hub/'


### PR DESCRIPTION
This PR bumps up Brew formula for Confluent Hub client since CP-5.0.1 is already released.