### PR TITLE
Install private common 5.2.x

### DIFF
--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -35,7 +35,7 @@ for repo in license-file-generator common; do
 done
 
 #private-common was deprecated in 5.3.x
-if [[ $RELEASE_TAG == 5.2.* ]] ;
+if [[ $RELEASE_TAG == v5.2.* ]] ;
 then
 	install_mvn_dependency private-common
 fi

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -34,12 +34,11 @@ for repo in license-file-generator common; do
 	install_mvn_dependency $repo
 done
 
+#private-common was deprecated in 5.3.x
 if [[ $RELEASE_TAG == 5.2.* ]] ;
 then
 	install_mvn_dependency private-common
 fi
-
-
 
 rm -rf hub-client
 git clone git@github.com:confluentinc/hub-client.git

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -34,6 +34,13 @@ for repo in license-file-generator common; do
 	install_mvn_dependency $repo
 done
 
+if [[ $RELEASE_TAG == 5.2.* ]] ;
+then
+	install_mvn_dependency private-common
+fi
+
+
+
 rm -rf hub-client
 git clone git@github.com:confluentinc/hub-client.git
 cd hub-client

--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -37,7 +37,10 @@ done
 #private-common was deprecated in 5.3.x
 if [[ $RELEASE_TAG == v5.2.* ]] ;
 then
+	echo "Installing private-common"
 	install_mvn_dependency private-common
+else
+	echo "Skipping installation of private-common"
 fi
 
 rm -rf hub-client


### PR DESCRIPTION
In order to be able to publish brew formula for 5.2.x, we need to install `private-common` to a local repository.