### PR TITLE
Don't bootstrap gradle if gradlew script is already present.

### DIFF
--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -14,21 +14,23 @@ version=${RELEASE_TAG:1}
 function install_mvn_dependency {
 	rm -rf $1
 	git clone git@github.com:confluentinc/$1.git
-	cd $1
+	pushd $1
 	git checkout $RELEASE_TAG
 	mvn clean install -DskipTests
-	cd -
+	popd
 }
 
-cd /tmp
+pushd /tmp
 
 rm -rf kafka
 git clone git@github.com:confluentinc/kafka.git
-cd kafka
+pushd kafka
 git checkout $RELEASE_TAG
-gradle
+if [ ! -x ./gradlew ]; then
+    gradle
+fi
 ./gradlew clients:install connect:api:install connect:runtime:install install_2_11
-cd -
+popd
 
 for repo in license-file-generator common; do
 	install_mvn_dependency $repo
@@ -45,7 +47,7 @@ fi
 
 rm -rf hub-client
 git clone git@github.com:confluentinc/hub-client.git
-cd hub-client
+pushd hub-client
 git checkout $RELEASE_TAG
 mvn clean package
 shasum -a 256 target/confluent-hub-client-*-package.tar.gz | cut -c1-64 > $(ls target/confluent-hub-client-*-package.tar.gz).sha256.txt
@@ -56,11 +58,11 @@ if $UPDATE_LATEST; then
 	aws s3 cp target/confluent-hub-client-*-package.tar.gz s3://client.hub.confluent.io/confluent-hub-client-latest.tar.gz
 	aws s3 cp target/confluent-hub-client-*-package.tar.gz.sha256.txt s3://client.hub.confluent.io/confluent-hub-client-latest.tar.gz.sha256.txt
 fi
-cd -
+popd
 
 rm -rf homebrew-confluent-hub-client
 git clone git@github.com:confluentinc/homebrew-confluent-hub-client.git
-cd homebrew-confluent-hub-client
+pushd homebrew-confluent-hub-client
 git checkout -b "prepare-$RELEASE_TAG"
 sed -i -E "s/version '.*'/version '$version'/g" Casks/confluent-hub-client.rb
 sed -i -E "s/sha256 '.*'/sha256 '$sha_sum'/g" Casks/confluent-hub-client.rb


### PR DESCRIPTION
- Kafka already has gradlew script present, run it rather than trying to
bootstrap gradle. Kafka projects as far back as 0.11 have a gradlew
script (which self bootstraps to the right version anyways).
- Use pushd and popd instead of `cd`, better shell scripting practice.