### PR TITLE
Update Brew command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run the following in your command-line:
 
 ```sh
 $ brew tap confluentinc/homebrew-confluent-hub-client 
-$ brew cask install confluent-hub-client
+$ brew install --cask confluent-hub-client
 ```
 
 # Release management


### PR DESCRIPTION
The old brew install command was failing with the error:
`Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.`

Updated the cmd to latest version