### PR TITLE
add force push

### DIFF
--- a/release-scripts/prepare-release-formula.sh
+++ b/release-scripts/prepare-release-formula.sh
@@ -71,4 +71,4 @@ sed -i -E "s/version '.*'/version '$version'/g" Casks/confluent-hub-client.rb
 sed -i -E "s/sha256 '.*'/sha256 '$sha_sum'/g" Casks/confluent-hub-client.rb
 git add Casks/confluent-hub-client.rb
 git commit -m "Bump up formula to $RELEASE_TAG"
-git push origin "prepare-$RELEASE_TAG"
+git push origin "prepare-$RELEASE_TAG" -f


### PR DESCRIPTION
During 7.6.2 release, the job failed to push the correct jar hash to prepare-v7.6.2 branch as the branch already existed (created as part of jenkins job)
This PR allows force push to update the jar hash